### PR TITLE
Rename utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# aiff_to_header
+# audio_to_header
 
-> Utility script creates c style `.h` header file based on an `.aiff` source
+> Utility script creates c style `.h` header file based on an audio source file
 
 Quick and dirty script for including audio samples in embedded projects.
 
@@ -12,9 +12,9 @@ Install dependencies:
 $ pip install -r requirements.txt
 ```
 
-Edit `aiff_to_header.py` file to specify parameters such as the C number type - the default format is `uint8_t`.
+Edit `audio_to_header.py` file to specify parameters such as the C number type - the default format is `uint8_t`.
 
-Run script and specify an input file (note this should be a single channel `.aiff` file):
+Run script and specify an input file (this has been tested with a a single channel `.aiff` file but may work with others - see soundfile dependency for compatibility):
 
 ```bash
 $ python aiff_to_header.py chirp.aiff

--- a/audio_to_header.py
+++ b/audio_to_header.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 '''
-    File name: aiff_to_header.py
+    File name: audio_to_header.py
     Author: Jared Ellison
     Date created: June 2019
     Python Version: 3.7.3


### PR DESCRIPTION
Rename utility as prompted by issue #2, this script is likely to work on other audio file types beyond `.aiff` based on support from the [SoundFile](https://pypi.org/project/SoundFile/) library, although for now it only handles a single channel output.